### PR TITLE
Update form Java 8 to Java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ RUN apt-get update -y \
     locales \
     bash \
     libgomp1 \
-    openjdk-8-jdk-headless \
+    openjdk-11-jdk-headless \
     git \
     maven \
     unzip \
     xmlstarlet \
-    && apt-get clean
+    && apt-get auto-clean -y
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
@@ -29,17 +29,19 @@ WORKDIR /languagetool
 
 RUN ["mvn", "--projects", "languagetool-standalone", "--also-make", "package", "-DskipTests", "--quiet"]
 
-RUN LANGUAGETOOL_DIST_VERSION=$(xmlstarlet sel -N "x=http://maven.apache.org/POM/4.0.0" -t -v "//x:project/x:properties/x:languagetool.version" pom.xml) && unzip /languagetool/languagetool-standalone/target/LanguageTool-${LANGUAGETOOL_DIST_VERSION}.zip -d /dist
+RUN LANGUAGETOOL_DIST_VERSION=$(xmlstarlet sel -N "x=http://maven.apache.org/POM/4.0.0" -t -v "//x:project/x:properties/x:languagetool.version" pom.xml) 
+	&& unzip /languagetool/languagetool-standalone/target/LanguageTool-${LANGUAGETOOL_DIST_VERSION}.zip -d /dist
 
 RUN LANGUAGETOOL_DIST_FOLDER=$(find /dist/ -name 'LanguageTool-*') && mv $LANGUAGETOOL_DIST_FOLDER /dist/LanguageTool
 
-FROM openjdk:8-jre-alpine
+FROM openjdk:11-jre-buster
 
-RUN apk update \
-    && apk add \
+RUN apt-get update -y \
+    && apt-get install -y \
     bash \
     libgomp \
-    gcompat
+    gcompat \
+	&& apt-get auto-clean -y
 
 ARG LANGUAGETOOL_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update -y \
     bash \
     libgomp \
     gcompat \
-	&& apt-get auto-clean -y
+    && apt-get auto-clean -y
 
 ARG LANGUAGETOOL_VERSION
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ docker run --rm -it -p 8010:8010 -e langtool_languageModel=/ngrams -v local/path
 ## Improving the spell checker
 
 > You can improve the spell checker without touching the dictionary. For single words (no spaces), you can add your words to one of these files:
-> * `spelling.txt`: words that the spell checker will ignore and use to generate corrections if someone types a similar word
-> * `ignore.txt`: words that the spell checker will ignore but not use to generate corrections
+> * `spelling.txt`: words that the spell checker will ignore and used to generate corrections if someone types a similar word
+> * `ignore.txt`: words that the spell checker will ignore but not used to generate corrections
 > * `prohibited.txt`: words that should be considered incorrect even though the spell checker would accept them
 
 *Source: [https://dev.languagetool.org/hunspell-support](https://dev.languagetool.org/hunspell-support)*
@@ -97,14 +97,14 @@ services:
         - 8010:8010  # Using default port from the image
     environment:
         - langtool_languageModel=/ngrams  # OPTIONAL: Using ngrams data
-        - Java_Xms=512m  # OPTIONAL: Setting a minimal Java heap size of 512 mib
-        - Java_Xmx=1g  # OPTIONAL: Setting a maximum Java heap size of 1 Gib
+        - Java_Xms=512m  # OPTIONAL: Setting a minimal Java heap size of 512 MiB
+        - Java_Xmx=1g  # OPTIONAL: Setting a maximum Java heap size of 1 GiB
     volumes:
         - /path/to/ngrams/data:/ngrams
 ```
 
 # Usage
-By default this image is configured to listen on port 8010 which deviates from the default port of LanguageTool 8081.
+By default, this image is configured to listen on port 8010 which deviates from the default port of LanguageTool 8081.
 
 An example cURL request:
 ```

--- a/start.sh
+++ b/start.sh
@@ -8,7 +8,7 @@ done
 
 if [ "$config_injected" = true ] ; then
     echo 'The following configuration is passed to LanguageTool:'
-	echo "$(cat config.properties)"
+    echo "$(cat config.properties)"
 fi
 
 Xms=${Java_Xms:-256m}


### PR DESCRIPTION
- Update form openjdk-8-jdk-headless to openjdk-8-jdk-headless
- Use openjdk:11-jre-buster instead of openjdk:8-jre-alpine as runtime environment inside the docker container
- Grammar fixes in README.md
- Whitespace fix in start.sh