### PR TITLE
Improve `apk` usage in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,7 @@ WORKDIR /languagetool
 
 FROM alpine:3.15.0
 
-RUN apk update \
-    && apk add \
+RUN apk add --no-cache \
     bash \
     libstdc++ \
     openjdk11-jre-headless


### PR DESCRIPTION
Use `--no-cache` with `apk add` without additional `apk upate` and also leave no cache to make the image tidier!