### PR TITLE
fix: Firefox extension can't connect to local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,8 @@ curl --data "language=en-US&text=a simple test" http://localhost:8010/v2/check
 ```
 
 Please refer to the official LanguageTool documentation for further usage instructions.
+
+# Known issues & workarounds
+
+If you experience problems when connecting local server to the official Firefox extension, see [cors-workaround](cors-workaround/).
+

--- a/cors-workaround/README.md
+++ b/cors-workaround/README.md
@@ -1,0 +1,41 @@
+# CORS Workaround
+
+A `docker-compose` setup to run a local instance from language-tool server in a Firefox extension compatible way.
+
+This configuration solves the https://github.com/Erikvl87/docker-languagetool/issues/40 problem (LT's Firefox extension refuses to connect to the local server because the CORS directives are not configured correctly).
+
+The `docker-compose.yml` file builds a minimal image based on NGINX Alpine and configures it to proxy the LT container with the CORS configuration and port that the extension expects.
+
+It also pipes NGINX logs to `stdout` for an easier debugging.
+
+
+
+### Structure
+```
+├── docker-compose.yml
+├── nginx
+│   ├── Dockerfile
+│   └── nginx.conf
+└── README.md
+```
+
+### Changes
+##### `docker-compose.yml`
+- *ngrams* are mounted from `\home\<user>\ngrams`.
+- Mapping for `cors` container to port 8081
+
+##### `nginx/Dockerfile`
+- NGINX logs are piped to `stdout`
+
+##### `nginx/nginx.conf`
+
+| conf                          | new value                        |
+| ----------------------------- | -------------------------------- |
+| `server`                      | `languagetool:8010;`             |
+| `listen`                      | `8081`                           |
+| `proxy_pass`                  | `http://language-tools/;`        |
+| `upstream`                    | `language-tools`                 |
+| `proxy_hide_header directive` | `'Access-Control-Allow-Origin';` |
+
+### Credits
+All credits to [@Erikvl87](https://github.com/Erikvl87) for the [docker-languagetool](https://github.com/Erikvl87/docker-languagetool) image and to [@maximillianfx](https://github.com/maximillianfx) for the [docker-nginx-cors](https://github.com/maximillianfx/docker-nginx-cors) image.

--- a/cors-workaround/docker-compose.yml
+++ b/cors-workaround/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  languagetool:
+    image: erikvl87/languagetool
+    container_name: languagetool
+    ports:
+        - "8010"
+    environment:
+        - langtool_languageModel=/ngrams  # OPTIONAL: Using ngrams data
+        - Java_Xms=512m  # OPTIONAL: Setting a minimal Java heap size of 512 mib
+        - Java_Xmx=1g  # OPTIONAL: Setting a maximum Java heap size of 1 Gib
+    volumes:
+        - /path/to/ngrams:/ngrams
+  cors:
+    build: nginx/.
+    container_name: cors
+    ports:
+      - "8081"

--- a/cors-workaround/nginx/Dockerfile
+++ b/cors-workaround/nginx/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:alpine
+RUN ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/nginx/error.log
+WORKDIR /etc/nginx
+COPY ./nginx.conf ./conf.d/default.conf
+EXPOSE 80
+ENTRYPOINT [ "nginx" ]
+CMD [ "-g", "daemon off;" ]

--- a/cors-workaround/nginx/nginx.conf
+++ b/cors-workaround/nginx/nginx.conf
@@ -1,0 +1,21 @@
+upstream language-tools {
+  # Could be host.docker.internal - Docker for Mac/Windows - the host itself
+  # Could be your API in a appropriate domain
+  # Could be other container in the same network, like container_name:port
+  server languagetool:8010;
+}
+
+server {
+  listen 8081;
+  server_name localhost;
+
+  location / {
+    proxy_hide_header 'Access-Control-Allow-Origin';
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Access-Control-Allow-Headers' 'Authorization,Accept,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,
+    X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+    add_header 'Access-Control-Allow-Methods' 'GET,POST,OPTIONS,PUT,DELETE,PATCH';
+
+    proxy_pass http://language-tools/;
+  }
+}


### PR DESCRIPTION
`docker-compose.yml` builds a NGINX image to act as reverse proxy in order to set CORS directives and port expected by FF extension.

fixes: #40 