### PR TITLE
Allow modifying `languagetool` logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+logback.xml

--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ An example startup configuration:
 docker run --rm -it -p 8010:8010 -e langtool_pipelinePrewarming=true -e Java_Xms=1g -e Java_Xmx=2g erikvl87/languagetool
 ```
 
+## Overwrite logging configuration
+To overwrite the [default LanguageTool logback.xml logging configuration](https://github.com/languagetool-org/languagetool/blob/master/languagetool-server/src/main/resources/logback.xml), create a new `logback.xml` file and mount it into the container.
+
+For example, create the following `logback.xml` file:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <logger name="org.languagetool" level="ERROR"/>
+</configuration>
+```
+
+An example startup configuration:
+
+```sh
+docker run --rm -it -p 8010:8010 -v /home/john/logback.xml:/LanguageTool/logback.xml erikvl87/languagetool
+```
+
+
 ## Using n-gram datasets
 > LanguageTool can make use of large n-gram data sets to detect errors with words that are often confused, like __their__ and __there__.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,4 @@ services:
       - Java_Xmx=1g                      # OPTIONAL: Setting a maximum Java heap size of 1 Gib
     volumes:
       - /path/to/ngrams/data:/ngrams     # OPTIONAL: The location of ngrams data on the local machine
+      - /path/to/logback.xml:/LanguageTool/logback.xml:ro  # OPTIONAL: Overwrite the logging configuration

--- a/start.sh
+++ b/start.sh
@@ -7,11 +7,30 @@ do
 done
 
 if [ "$config_injected" = true ] ; then
-    echo 'The following configuration is passed to LanguageTool:'
-	echo "$(cat config.properties)"
+  echo 'The following configuration is passed to LanguageTool:'
+  cat config.properties
 fi
 
 Xms=${Java_Xms:-256m}
 Xmx=${Java_Xmx:-512m}
 
-exec java -Xms$Xms -Xmx$Xmx -cp languagetool-server.jar org.languagetool.server.HTTPServer --port 8010 --public --allow-origin '*' --config config.properties
+PRIO_ARGS=(  
+  "-Xms$Xms"
+  "-Xmx$Xmx"
+)
+
+if [ -f /LanguageTool/logback.xml ] ; then
+  PRIO_ARGS+=("-Dlogback.configurationFile=/LanguageTool/logback.xml")
+fi
+
+LT_ARGS=(
+  -cp languagetool-server.jar
+  org.languagetool.server.HTTPServer
+  --port 8010
+  --public
+  --allow-origin '*'
+  --config config.properties
+)
+
+set -x
+exec java "${PRIO_ARGS[@]}" "${LT_ARGS[@]}"


### PR DESCRIPTION
Inspired by https://github.com/languagetool-org/languagetool/issues/8882.

On top of the default template, a simple
```xml
<logger name="org.languagetool.server.LanguageToolHttpHandler" level="WARNING" />
```
should* be enough to silence the continuous spam.

Additionally, for `start.sh`:
* Fix formatting
* Fix a _useless use of `cat`_
* Move args to the `ARGS` array, for easier manipulation

*should: My internet is abysmal; building locally to verify is a disaster