### PR TITLE
Improve docker-compose file indentation

### DIFF
--- a/cors-workaround/docker-compose.yml
+++ b/cors-workaround/docker-compose.yml
@@ -4,13 +4,13 @@ services:
     image: erikvl87/languagetool
     container_name: languagetool
     ports:
-        - "8010"
+      - "8010"
     environment:
-        - langtool_languageModel=/ngrams  # OPTIONAL: Using ngrams data
-        - Java_Xms=512m  # OPTIONAL: Setting a minimal Java heap size of 512 mib
-        - Java_Xmx=1g  # OPTIONAL: Setting a maximum Java heap size of 1 Gib
+      - langtool_languageModel=/ngrams  # OPTIONAL: Using ngrams data
+      - Java_Xms=512m  # OPTIONAL: Setting a minimal Java heap size of 512 mib
+      - Java_Xmx=1g  # OPTIONAL: Setting a maximum Java heap size of 1 Gib
     volumes:
-        - /path/to/ngrams:/ngrams
+      - /path/to/ngrams:/ngrams
   cors:
     build: nginx/.
     container_name: cors


### PR DESCRIPTION
To be consistent with an indentation level of 2, this fixes YAML indentation of the docker-compose file.

No functional changes were made (only stylistic ones).