### PR TITLE
use exec to run Java

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -14,5 +14,4 @@ fi
 Xms=${Java_Xms:-256m}
 Xmx=${Java_Xmx:-512m}
 
-set -x
-java -Xms$Xms -Xmx$Xmx -cp languagetool-server.jar org.languagetool.server.HTTPServer --port 8010 --public --allow-origin '*' --config config.properties
+exec java -Xms$Xms -Xmx$Xmx -cp languagetool-server.jar org.languagetool.server.HTTPServer --port 8010 --public --allow-origin '*' --config config.properties


### PR DESCRIPTION
This PR changes start.sh so that it uses `exec` to run Java.

Without using `exec`, the Docker engine does not seem to be able to correctly signal the Java process to shut down, resulting in the engine waiting for the container. It will eventually kill the process after some timeout. By using `exec`, the signaling works, and the container shuts down immediately.