### PR TITLE
fix link anchor and apply link content

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ home/
 │  │  │  ├─ 3grams/
 ```
 
-Mount the local ngrams directory to the `/ngrams` directory in the Docker container [using the `-v` configuration]([https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only](https://docs.docker.com/engine/reference/commandline/container_run/#read-only)) and set the `languageModel` configuration to the `/ngrams` folder.
+Mount the local ngrams directory to the `/ngrams` directory in the Docker container [using the `-v` configuration](https://docs.docker.com/engine/reference/commandline/container_run/#read-only) and set the `languageModel` configuration to the `/ngrams` folder.
 
 An example startup configuration:
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ home/
 │  │  │  ├─ 3grams/
 ```
 
-Mount the local ngrams directory to the `/ngrams` directory in the Docker container [using the `-v` configuration](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only) and set the `languageModel` configuration to the `/ngrams` folder.
+Mount the local ngrams directory to the `/ngrams` directory in the Docker container [using the `-v` configuration]([https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only](https://docs.docker.com/engine/reference/commandline/container_run/#read-only)) and set the `languageModel` configuration to the `/ngrams` folder.
 
 An example startup configuration:
 
 ```sh
-docker run --rm -it -p 8010:8010 -e langtool_languageModel=/ngrams -v home/john/ngrams:/ngrams erikvl87/languagetool
+docker run --rm -it -p 8010:8010 -e langtool_languageModel=/ngrams -v /home/john/ngrams:/ngrams:ro erikvl87/languagetool
 ```
 
 ## Improving the spell checker


### PR DESCRIPTION
The anchor didn't work (anymore) and the linked paragraph hasn't been applied in the example (`:ro`)