### PR TITLE
Add fasttext

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ COPY arm64-workaround/hunspell.sh arm64-workaround/hunspell.sh
 RUN chmod +x arm64-workaround/hunspell.sh
 RUN bash -c "arm64-workaround/hunspell.sh"
 
+WORKDIR /fastText
+RUN wget https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin
+
 WORKDIR /languagetool
 
 # Note: When changing the base image, verify that the hunspell.sh workaround is
@@ -58,11 +61,16 @@ RUN apk add --no-cache \
     curl \
     libc6-compat \
     libstdc++ \
-    openjdk11-jre-headless
+    openjdk11-jre-headless \
+    fasttext
 
 RUN addgroup -S languagetool && adduser -S languagetool -G languagetool
 
 COPY --chown=languagetool --from=build /dist .
+
+WORKDIR /fastText
+COPY --chown=languagetool --from=build /fastText .
+
 
 WORKDIR /LanguageTool
 

--- a/start.sh
+++ b/start.sh
@@ -6,6 +6,9 @@ do
   echo "${varname#'langtool_'}="${!varname} >> config.properties
 done
 
+echo "fasttextModel=/fastText/lid.176.bin" >> config.properties
+echo "fasttextBinary=$(which fasttext)" >> config.properties
+
 if [ "$config_injected" = true ] ; then
   echo 'The following configuration is passed to LanguageTool:'
   cat config.properties


### PR DESCRIPTION
#70

fix `GMT WARN  org.languagetool.language.identifier.DefaultLanguageIdentifier fastText not configured - language detection performance will be degraded. See https://dev.languagetool.org/http-server#starting-from-command-line for instructions.`