### PR TITLE
Fix runtime for LanguageTool v6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN apk add --no-cache \
     curl \
     libc6-compat \
     libstdc++ \
-    openjdk11-jre-headless
+    openjdk17-jre-headless
 
 RUN addgroup -S languagetool && adduser -S languagetool -G languagetool
 


### PR DESCRIPTION
Potentially fixes https://github.com/Erikvl87/docker-languagetool/issues/107

**WARNING**: I'm not very familiar with Java ecosystem, so please verify the changes are indeed correct

Package ref: https://pkgs.alpinelinux.org/package/v3.21/community/x86_64/openjdk17-jre-headless