### PR TITLE
Update restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
   languagetool:
     image: erikvl87/languagetool
     container_name: languagetool
+    restart: always
     ports:
       - 8010:8010                        # Using default port from the image
     environment:
@@ -15,3 +16,4 @@ services:
     volumes:
       - /path/to/ngrams/data:/ngrams     # OPTIONAL: The location of ngrams data on the local machine
       - /path/to/logback.xml:/LanguageTool/logback.xml:ro  # OPTIONAL: Overwrite the logging configuration
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   languagetool:
     image: erikvl87/languagetool
     container_name: languagetool
-    restart: always
+    restart: unless-stopped
     ports:
       - 8010:8010                        # Using default port from the image
     environment:


### PR DESCRIPTION
Currently, the container will not automatically start when Docker is started (usually also refers to system startup).
Changing restart policy can help.