### PR TITLE
fix: make config.properties generation idempotent across restarts

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,10 @@
 
 config_injected=false
 
+# reset to just the container-managed lines; loop below re-appends fresh config on start
+grep -E '^(fasttextModel|fasttextBinary)=' config.properties > config.properties.new
+mv config.properties.new config.properties
+
 for varname in ${!langtool_*}
 do
   key="${varname#'langtool_'}"


### PR DESCRIPTION
`config.properties` only ever gets appended to (`>>`), never reset. Since a container restart reuses the same writable layer, every restart re-appends the current env-derived config on top of what's already there. This causes unbounded duplication.

This PR updates `start.sh` to reset the file to just the container-managed `fasttextModel`/`fasttextBinary` lines before the loop runs, so each start rebuilds the config from scratch.